### PR TITLE
CU-5: Fix Problems With Relative Routes on Installation

### DIFF
--- a/amazonsns.php
+++ b/amazonsns.php
@@ -2,8 +2,6 @@
 
 require_once __DIR__ . '/vendor/autoload.php';
 require_once 'amazonsns.civix.php';
-require_once 'api/api.php';
-require_once 'sites/all/modules/civicrm/api/v3/utils.php';
 
 /**
  * Implements hook_civicrm_config().

--- a/templates/CRM/Amazonsns/BatchSMSTypeField.tpl
+++ b/templates/CRM/Amazonsns/BatchSMSTypeField.tpl
@@ -4,27 +4,29 @@
     <td nowrap>SMS Type (Amazon SNS):</td>
     <td>{$form.sms_type.html}</td>
   </tr>
-  <tr id="amazonsns-phone-validation">
-    <td colspan="2">
-      <div id="amazonsns-validation-alert">
-        <p>Found {$invalidPhonesCount} invalid phone{if $invalidPhonesCount > 1}s{/if} on selected groups! Phone numbers to be used to send SMS messages through Amazon SNS require to follow the E.164 format!</p>
-        <p><a href="http://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html" target="_blank">More information...</a></p>
-        <p>Invalid phones:</p>
-        <ul>
-          {foreach from=$invalidPhones item="phoneData"}
-            <li>
-              <a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$phoneData.contact_id`"}">
-                {$phoneData.contact_name} - {$phoneData.phone}
-              </a>
-            </li>
-          {/foreach}
-          {if $invalidPhonesCount > 20}
-            <li>...</li>
-          {/if}
-        </ul>
-      </div>
-    </td>
-  </tr>
+  {if $invalidPhonesCount > 0}
+    <tr id="amazonsns-phone-validation">
+      <td colspan="2">
+        <div id="amazonsns-validation-alert">
+          <p>Found {$invalidPhonesCount} invalid phone{if $invalidPhonesCount > 1}s{/if} on selected groups! Phone numbers to be used to send SMS messages through Amazon SNS require to follow the E.164 format!</p>
+          <p><a href="http://docs.aws.amazon.com/sns/latest/dg/sms_publish-to-phone.html" target="_blank">More information...</a></p>
+          <p>Invalid phones:</p>
+          <ul>
+            {foreach from=$invalidPhones item="phoneData"}
+              <li>
+                <a href="{crmURL p="civicrm/contact/view" q="reset=1&cid=`$phoneData.contact_id`"}">
+                  {$phoneData.contact_name} - {$phoneData.phone}
+                </a>
+              </li>
+            {/foreach}
+            {if $invalidPhonesCount > 20}
+              <li>...</li>
+            {/if}
+          </ul>
+        </div>
+      </td>
+    </tr>
+  {/if}
 </table>
 <script type="text/javascript">
   {literal}


### PR DESCRIPTION
## Overview
On non-standard CiviCRM installations, the inclusion of files using relative routes were generating errors on amazonsns extension installation. These inclusions were found to be unnecesary, as they are already part of CiviCRM framework.

## Before
Installation could fail if 'api/api.php' and 'sites/all/modules/civicrm/api/v3/utils.php' were not found in include path.

## After
Removed require_once instructions that were unnecesary.  Also fixed a problem on batch SMS sending form, where for Amazon SNS provider always showed the phone format alert, even if the count of invalid phones was 0.