### PR TITLE
COMCL-28: Remove .gitignore when build a tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build tarball
         shell: bash
         run: |
-          rm -r ${{ env.WORKING_DIR }}/{.git,.github}
+          rm -r ${{ env.WORKING_DIR }}/{.git,.github,.gitignore}
           tar czf ${{ env.WORKING_DIR }}.tar.gz ${{ env.WORKING_DIR }}
 
       - name: Upload Release Asset


### PR DESCRIPTION
## Overview
This PR is to remove .gitignore from the tarball after a release is created. 

## Before
.gitignore was presented in a tarball. 

## After
.gitignore will be excluded from the tarball. 

## Technical Details

.gitignore prevents developer to push vendor directory into the repository and then the tarball is built and gitignore was not remove so it also prevents vendor directory to be pushed into client project repository. 
