### PR TITLE
COMCL-101: Regenerate civix file and Base upgrader class

### DIFF
--- a/CRM/Amazonsns/Upgrader/Base.php
+++ b/CRM/Amazonsns/Upgrader/Base.php
@@ -1,6 +1,7 @@
 <?php
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use CRM_Amazonsns_ExtensionUtil as E;
 
 /**
  * Base class which provides helpers to execute upgrade logic
@@ -8,9 +9,9 @@
 class CRM_Amazonsns_Upgrader_Base {
 
   /**
-   * @var varies, subclass of ttis
+   * @var CRM_Amazonsns_Upgrader_Base
    */
-  static $instance;
+  public static $instance;
 
   /**
    * @var CRM_Queue_TaskContext
@@ -18,22 +19,25 @@ class CRM_Amazonsns_Upgrader_Base {
   protected $ctx;
 
   /**
-   * @var string, eg 'com.example.myextension'
+   * @var string
+   *   eg 'com.example.myextension'
    */
   protected $extensionName;
 
   /**
-   * @var string, full path to the extension's source tree
+   * @var string
+   *   full path to the extension's source tree
    */
   protected $extensionDir;
 
   /**
-   * @var array(revisionNumber) sorted numerically
+   * @var array
+   *   sorted numerically
    */
   private $revisions;
 
   /**
-   * @var boolean
+   * @var bool
    *   Flag to clean up extension revision data in civicrm_setting
    */
   private $revisionStorageIsDeprecated = FALSE;
@@ -41,12 +45,11 @@ class CRM_Amazonsns_Upgrader_Base {
   /**
    * Obtain a reference to the active upgrade handler.
    */
-  static public function instance() {
+  public static function instance() {
     if (!self::$instance) {
-      // FIXME auto-generate
       self::$instance = new CRM_Amazonsns_Upgrader(
         'uk.compucorp.civicrm.amazonsns',
-        realpath(__DIR__ . '/../../../')
+        E::path()
       );
     }
     return self::$instance;
@@ -58,19 +61,25 @@ class CRM_Amazonsns_Upgrader_Base {
    * Note: Each upgrader instance should only be associated with one
    * task-context; otherwise, this will be non-reentrant.
    *
-   * @code
+   * ```
    * CRM_Amazonsns_Upgrader_Base::_queueAdapter($ctx, 'methodName', 'arg1', 'arg2');
-   * @endcode
+   * ```
    */
-  static public function _queueAdapter() {
+  public static function _queueAdapter() {
     $instance = self::instance();
     $args = func_get_args();
     $instance->ctx = array_shift($args);
     $instance->queue = $instance->ctx->queue;
     $method = array_shift($args);
-    return call_user_func_array(array($instance, $method), $args);
+    return call_user_func_array([$instance, $method], $args);
   }
 
+  /**
+   * CRM_Amazonsns_Upgrader_Base constructor.
+   *
+   * @param $extensionName
+   * @param $extensionDir
+   */
   public function __construct($extensionName, $extensionDir) {
     $this->extensionName = $extensionName;
     $this->extensionDir = $extensionDir;
@@ -81,7 +90,8 @@ class CRM_Amazonsns_Upgrader_Base {
   /**
    * Run a CustomData file.
    *
-   * @param string $relativePath the CustomData XML file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
   public function executeCustomDataFile($relativePath) {
@@ -92,11 +102,12 @@ class CRM_Amazonsns_Upgrader_Base {
   /**
    * Run a CustomData file
    *
-   * @param string $xml_file  the CustomData XML file path (absolute path)
+   * @param string $xml_file
+   *   the CustomData XML file path (absolute path)
    *
    * @return bool
    */
-  protected static function executeCustomDataFileByAbsPath($xml_file) {
+  protected function executeCustomDataFileByAbsPath($xml_file) {
     $import = new CRM_Utils_Migrate_Import();
     $import->run($xml_file);
     return TRUE;
@@ -105,7 +116,8 @@ class CRM_Amazonsns_Upgrader_Base {
   /**
    * Run a SQL file.
    *
-   * @param string $relativePath the SQL file path (relative to this extension's dir)
+   * @param string $relativePath
+   *   the SQL file path (relative to this extension's dir)
    *
    * @return bool
    */
@@ -118,10 +130,14 @@ class CRM_Amazonsns_Upgrader_Base {
   }
 
   /**
+   * Run the sql commands in the specified file.
+   *
    * @param string $tplFile
    *   The SQL file path (relative to this extension's dir).
    *   Ex: "sql/mydata.mysql.tpl".
+   *
    * @return bool
+   * @throws \CRM_Core_Exception
    */
   public function executeSqlTemplate($tplFile) {
     // Assign multilingual variable to Smarty.
@@ -140,17 +156,19 @@ class CRM_Amazonsns_Upgrader_Base {
    * Run one SQL query.
    *
    * This is just a wrapper for CRM_Core_DAO::executeSql, but it
-   * provides syntatic sugar for queueing several tasks that
+   * provides syntactic sugar for queueing several tasks that
    * run different queries
+   *
+   * @return bool
    */
-  public function executeSql($query, $params = array()) {
+  public function executeSql($query, $params = []) {
     // FIXME verify that we raise an exception on error
     CRM_Core_DAO::executeQuery($query, $params);
     return TRUE;
   }
 
   /**
-   * Syntatic sugar for enqueuing a task which calls a function in this class.
+   * Syntactic sugar for enqueuing a task which calls a function in this class.
    *
    * The task is weighted so that it is processed
    * as part of the currently-pending revision.
@@ -162,11 +180,11 @@ class CRM_Amazonsns_Upgrader_Base {
     $args = func_get_args();
     $title = array_shift($args);
     $task = new CRM_Queue_Task(
-      array(get_class($this), '_queueAdapter'),
+      [get_class($this), '_queueAdapter'],
       $args,
       $title
     );
-    return $this->queue->createItem($task, array('weight' => -1));
+    return $this->queue->createItem($task, ['weight' => -1]);
   }
 
   // ******** Revision-tracking helpers ********
@@ -192,6 +210,8 @@ class CRM_Amazonsns_Upgrader_Base {
 
   /**
    * Add any pending revisions to the queue.
+   *
+   * @param CRM_Queue_Queue $queue
    */
   public function enqueuePendingRevisions(CRM_Queue_Queue $queue) {
     $this->queue = $queue;
@@ -199,23 +219,23 @@ class CRM_Amazonsns_Upgrader_Base {
     $currentRevision = $this->getCurrentRevision();
     foreach ($this->getRevisions() as $revision) {
       if ($revision > $currentRevision) {
-        $title = ts('Upgrade %1 to revision %2', array(
+        $title = E::ts('Upgrade %1 to revision %2', [
           1 => $this->extensionName,
           2 => $revision,
-        ));
+        ]);
 
         // note: don't use addTask() because it sets weight=-1
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('upgrade_' . $revision),
+          [get_class($this), '_queueAdapter'],
+          ['upgrade_' . $revision],
           $title
         );
         $this->queue->createItem($task);
 
         $task = new CRM_Queue_Task(
-          array(get_class($this), '_queueAdapter'),
-          array('setCurrentRevision', $revision),
+          [get_class($this), '_queueAdapter'],
+          ['setCurrentRevision', $revision],
           $title
         );
         $this->queue->createItem($task);
@@ -226,11 +246,12 @@ class CRM_Amazonsns_Upgrader_Base {
   /**
    * Get a list of revisions.
    *
-   * @return array(revisionNumbers) sorted numerically
+   * @return array
+   *   revisionNumbers sorted numerically
    */
   public function getRevisions() {
     if (!is_array($this->revisions)) {
-      $this->revisions = array();
+      $this->revisions = [];
 
       $clazz = new ReflectionClass(get_class($this));
       $methods = $clazz->getMethods();
@@ -255,7 +276,7 @@ class CRM_Amazonsns_Upgrader_Base {
 
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
-    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+    if ($revision = \Civi::settings()->get($key)) {
       $this->revisionStorageIsDeprecated = TRUE;
     }
     return $revision;
@@ -280,7 +301,7 @@ class CRM_Amazonsns_Upgrader_Base {
   // ******** Hook delegates ********
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
    */
   public function onInstall() {
     $files = glob($this->extensionDir . '/sql/*_install.sql');
@@ -301,26 +322,26 @@ class CRM_Amazonsns_Upgrader_Base {
         $this->executeCustomDataFileByAbsPath($file);
       }
     }
-    if (is_callable(array($this, 'install'))) {
+    if (is_callable([$this, 'install'])) {
       $this->install();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
    */
   public function onPostInstall() {
     $revisions = $this->getRevisions();
     if (!empty($revisions)) {
       $this->setCurrentRevision(max($revisions));
     }
-    if (is_callable(array($this, 'postInstall'))) {
+    if (is_callable([$this, 'postInstall'])) {
       $this->postInstall();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
    */
   public function onUninstall() {
     $files = glob($this->extensionDir . '/sql/*_uninstall.mysql.tpl');
@@ -329,7 +350,7 @@ class CRM_Amazonsns_Upgrader_Base {
         $this->executeSqlTemplate($file);
       }
     }
-    if (is_callable(array($this, 'uninstall'))) {
+    if (is_callable([$this, 'uninstall'])) {
       $this->uninstall();
     }
     $files = glob($this->extensionDir . '/sql/*_uninstall.sql');
@@ -341,21 +362,21 @@ class CRM_Amazonsns_Upgrader_Base {
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
    */
   public function onEnable() {
     // stub for possible future use
-    if (is_callable(array($this, 'enable'))) {
+    if (is_callable([$this, 'enable'])) {
       $this->enable();
     }
   }
 
   /**
-   * @see https://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+   * @see https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
    */
   public function onDisable() {
     // stub for possible future use
-    if (is_callable(array($this, 'disable'))) {
+    if (is_callable([$this, 'disable'])) {
       $this->disable();
     }
   }
@@ -363,7 +384,7 @@ class CRM_Amazonsns_Upgrader_Base {
   public function onUpgrade($op, CRM_Queue_Queue $queue = NULL) {
     switch ($op) {
       case 'check':
-        return array($this->hasPendingRevisions());
+        return [$this->hasPendingRevisions()];
 
       case 'enqueue':
         return $this->enqueuePendingRevisions($queue);

--- a/amazonsns.civix.php
+++ b/amazonsns.civix.php
@@ -3,9 +3,86 @@
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
 
 /**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class CRM_Amazonsns_ExtensionUtil {
+  const SHORT_NAME = 'amazonsns';
+  const LONG_NAME = 'uk.compucorp.civicrm.amazonsns';
+  const CLASS_PREFIX = 'CRM_Amazonsns';
+
+  /**
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
+   */
+  public static function ts($text, $params = []) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = [self::LONG_NAME, NULL];
+    }
+    return ts($text, $params);
+  }
+
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function url($file = NULL) {
+    if ($file === NULL) {
+      return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
+    }
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: NULL.
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo'.
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
+  public static function path($file = NULL) {
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($file === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
+  }
+
+}
+
+use CRM_Amazonsns_ExtensionUtil as E;
+
+/**
  * (Delegated) Implements hook_civicrm_config().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_config
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_config
  */
 function _amazonsns_civix_civicrm_config(&$config = NULL) {
   static $configured = FALSE;
@@ -23,7 +100,7 @@ function _amazonsns_civix_civicrm_config(&$config = NULL) {
     array_unshift($template->template_dir, $extDir);
   }
   else {
-    $template->template_dir = array($extDir, $template->template_dir);
+    $template->template_dir = [$extDir, $template->template_dir];
   }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
@@ -35,7 +112,7 @@ function _amazonsns_civix_civicrm_config(&$config = NULL) {
  *
  * @param $files array(string)
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_xmlMenu
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_xmlMenu
  */
 function _amazonsns_civix_civicrm_xmlMenu(&$files) {
   foreach (_amazonsns_civix_glob(__DIR__ . '/xml/Menu/*.xml') as $file) {
@@ -46,7 +123,7 @@ function _amazonsns_civix_civicrm_xmlMenu(&$files) {
 /**
  * Implements hook_civicrm_install().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_install
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _amazonsns_civix_civicrm_install() {
   _amazonsns_civix_civicrm_config();
@@ -58,12 +135,12 @@ function _amazonsns_civix_civicrm_install() {
 /**
  * Implements hook_civicrm_postInstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
 function _amazonsns_civix_civicrm_postInstall() {
   _amazonsns_civix_civicrm_config();
   if ($upgrader = _amazonsns_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onPostInstall'))) {
+    if (is_callable([$upgrader, 'onPostInstall'])) {
       $upgrader->onPostInstall();
     }
   }
@@ -72,7 +149,7 @@ function _amazonsns_civix_civicrm_postInstall() {
 /**
  * Implements hook_civicrm_uninstall().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_uninstall
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
 function _amazonsns_civix_civicrm_uninstall() {
   _amazonsns_civix_civicrm_config();
@@ -84,12 +161,12 @@ function _amazonsns_civix_civicrm_uninstall() {
 /**
  * (Delegated) Implements hook_civicrm_enable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_enable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _amazonsns_civix_civicrm_enable() {
   _amazonsns_civix_civicrm_config();
   if ($upgrader = _amazonsns_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onEnable'))) {
+    if (is_callable([$upgrader, 'onEnable'])) {
       $upgrader->onEnable();
     }
   }
@@ -98,13 +175,13 @@ function _amazonsns_civix_civicrm_enable() {
 /**
  * (Delegated) Implements hook_civicrm_disable().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_disable
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  * @return mixed
  */
 function _amazonsns_civix_civicrm_disable() {
   _amazonsns_civix_civicrm_config();
   if ($upgrader = _amazonsns_civix_upgrader()) {
-    if (is_callable(array($upgrader, 'onDisable'))) {
+    if (is_callable([$upgrader, 'onDisable'])) {
       $upgrader->onDisable();
     }
   }
@@ -116,10 +193,11 @@ function _amazonsns_civix_civicrm_disable() {
  * @param $op string, the type of operation being performed; 'check' or 'enqueue'
  * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
  *
- * @return mixed  based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *                for 'enqueue', returns void
+ * @return mixed
+ *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
+ *   for 'enqueue', returns void
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_upgrade
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
  */
 function _amazonsns_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
   if ($upgrader = _amazonsns_civix_upgrader()) {
@@ -140,22 +218,23 @@ function _amazonsns_civix_upgrader() {
 }
 
 /**
- * Search directory tree for files which match a glob pattern
+ * Search directory tree for files which match a glob pattern.
  *
  * Note: Dot-directories (like "..", ".git", or ".svn") will be ignored.
  * Note: In Civi 4.3+, delegate to CRM_Utils_File::findFiles()
  *
- * @param $dir string, base dir
- * @param $pattern string, glob pattern, eg "*.txt"
- * @return array(string)
+ * @param string $dir base dir
+ * @param string $pattern , glob pattern, eg "*.txt"
+ *
+ * @return array
  */
 function _amazonsns_civix_find_files($dir, $pattern) {
-  if (is_callable(array('CRM_Utils_File', 'findFiles'))) {
+  if (is_callable(['CRM_Utils_File', 'findFiles'])) {
     return CRM_Utils_File::findFiles($dir, $pattern);
   }
 
-  $todos = array($dir);
-  $result = array();
+  $todos = [$dir];
+  $result = [];
   while (!empty($todos)) {
     $subdir = array_shift($todos);
     foreach (_amazonsns_civix_glob("$subdir/$pattern") as $match) {
@@ -166,7 +245,7 @@ function _amazonsns_civix_find_files($dir, $pattern) {
     if ($dh = opendir($subdir)) {
       while (FALSE !== ($entry = readdir($dh))) {
         $path = $subdir . DIRECTORY_SEPARATOR . $entry;
-        if ($entry{0} == '.') {
+        if ($entry[0] == '.') {
         }
         elseif (is_dir($path)) {
           $todos[] = $path;
@@ -177,25 +256,27 @@ function _amazonsns_civix_find_files($dir, $pattern) {
   }
   return $result;
 }
+
 /**
  * (Delegated) Implements hook_civicrm_managed().
  *
  * Find any *.mgd.php files, merge their content, and return.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_managed
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_managed
  */
 function _amazonsns_civix_civicrm_managed(&$entities) {
   $mgdFiles = _amazonsns_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = 'uk.compucorp.civicrm.amazonsns';
+        $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }
@@ -207,7 +288,7 @@ function _amazonsns_civix_civicrm_managed(&$entities) {
  *
  * Note: This hook only runs in CiviCRM 4.4+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_caseTypes
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_caseTypes
  */
 function _amazonsns_civix_civicrm_caseTypes(&$caseTypes) {
   if (!is_dir(__DIR__ . '/xml/case')) {
@@ -218,14 +299,13 @@ function _amazonsns_civix_civicrm_caseTypes(&$caseTypes) {
     $name = preg_replace('/\.xml$/', '', basename($file));
     if ($name != CRM_Case_XMLProcessor::mungeCaseType($name)) {
       $errorMessage = sprintf("Case-type file name is malformed (%s vs %s)", $name, CRM_Case_XMLProcessor::mungeCaseType($name));
-      CRM_Core_Error::fatal($errorMessage);
-      // throw new CRM_Core_Exception($errorMessage);
+      throw new CRM_Core_Exception($errorMessage);
     }
-    $caseTypes[$name] = array(
-      'module' => 'uk.compucorp.civicrm.amazonsns',
+    $caseTypes[$name] = [
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
-    );
+    ];
   }
 }
 
@@ -236,7 +316,7 @@ function _amazonsns_civix_civicrm_caseTypes(&$caseTypes) {
  *
  * Note: This hook only runs in CiviCRM 4.5+.
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_angularModules
  */
 function _amazonsns_civix_civicrm_angularModules(&$angularModules) {
   if (!is_dir(__DIR__ . '/ang')) {
@@ -248,9 +328,28 @@ function _amazonsns_civix_civicrm_angularModules(&$angularModules) {
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = 'uk.compucorp.civicrm.amazonsns';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
+  }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_themes().
+ *
+ * Find any and return any files matching "*.theme.php"
+ */
+function _amazonsns_civix_civicrm_themes(&$themes) {
+  $files = _amazonsns_civix_glob(__DIR__ . '/*.theme.php');
+  foreach ($files as $file) {
+    $themeMeta = include $file;
+    if (empty($themeMeta['name'])) {
+      $themeMeta['name'] = preg_replace(':\.theme\.php$:', '', basename($file));
+    }
+    if (empty($themeMeta['ext'])) {
+      $themeMeta['ext'] = E::LONG_NAME;
+    }
+    $themes[$themeMeta['name']] = $themeMeta;
   }
 }
 
@@ -264,29 +363,34 @@ function _amazonsns_civix_civicrm_angularModules(&$angularModules) {
  *
  * @link http://php.net/glob
  * @param string $pattern
- * @return array, possibly empty
+ *
+ * @return array
  */
 function _amazonsns_civix_glob($pattern) {
   $result = glob($pattern);
-  return is_array($result) ? $result : array();
+  return is_array($result) ? $result : [];
 }
 
 /**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *
  * @param array $menu - menu hierarchy
- * @param string $path - path where insertion should happen (ie. Administer/System Settings)
- * @param array $item - menu you need to insert (parent/child attributes will be filled for you)
+ * @param string $path - path to parent of this item, e.g. 'my_extension/submenu'
+ *    'Mailing', or 'Administer/System Settings'
+ * @param array $item - the item to insert (parent/child attributes will be
+ *    filled for you)
+ *
+ * @return bool
  */
 function _amazonsns_civix_insert_navigation_menu(&$menu, $path, $item) {
   // If we are done going down the path, insert menu
   if (empty($path)) {
-    $menu[] = array(
-      'attributes' => array_merge(array(
+    $menu[] = [
+      'attributes' => array_merge([
         'label'      => CRM_Utils_Array::value('name', $item),
         'active'     => 1,
-      ), $item),
-    );
+      ], $item),
+    ];
     return TRUE;
   }
   else {
@@ -297,9 +401,9 @@ function _amazonsns_civix_insert_navigation_menu(&$menu, $path, $item) {
     foreach ($menu as $key => &$entry) {
       if ($entry['attributes']['name'] == $first) {
         if (!isset($entry['child'])) {
-          $entry['child'] = array();
+          $entry['child'] = [];
         }
-        $found = _amazonsns_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _amazonsns_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;
@@ -310,7 +414,7 @@ function _amazonsns_civix_insert_navigation_menu(&$menu, $path, $item) {
  * (Delegated) Implements hook_civicrm_navigationMenu().
  */
 function _amazonsns_civix_navigationMenu(&$nodes) {
-  if (!is_callable(array('CRM_Core_BAO_Navigation', 'fixNavigationMenu'))) {
+  if (!is_callable(['CRM_Core_BAO_Navigation', 'fixNavigationMenu'])) {
     _amazonsns_civix_fixNavigationMenu($nodes);
   }
 }
@@ -352,17 +456,22 @@ function _amazonsns_civix_fixNavigationMenuItems(&$nodes, &$maxNavID, $parentID)
 /**
  * (Delegated) Implements hook_civicrm_alterSettingsFolders().
  *
- * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterSettingsFolders
  */
 function _amazonsns_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
+}
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
+ */
+function _amazonsns_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes = array_merge($entityTypes, []);
 }


### PR DESCRIPTION
## Overview

This PR fixes is to updates civix file and an upgrader base class.  The base class and civix file are generated automatically by running `civix generate:upgrader
`
The reason for regenerating the civix file and base upgrader class because CiviCRM changed the way they handle warning for using a deprecated function.  See this [PR ](https://github.com/civicrm/civicrm-core/pull/19256).

The changed will always throw use deprecated warning if the deprecated function is used in anywhere, for example, Drupal module, CiviCRM extension. This would not have an issue we install the extension / module via user interface. However, when we use Drush site-install command to install the Drupal site that ship with a Drupal profile that install the extension when creating a site. 

Any module or extension that use CiviCRM's deprecated function in the installation hook, upgrade hook, the E_USER_DEPRECATED warning will throw during installation, but Drush handles deprecated messages as an error rather than a warning.  

Since the old civix file and Base class are using the deprecated functions, we will also receive the error duration installation, for this reason, the deployment will always fail. This PR fixes this.  

### Note 

PR for fixing this issue in Drush has been created and merged to Druah 8.x https://github.com/drush-ops/drush/pull/4565, but we do not have a timescale for new Drush version to release, thus we fixed the extension. 

