### PR TITLE
CIVIPLMMI-172: Remove gitignore File While Creating Build Branches

### DIFF
--- a/.github/workflows/create-build-branch.yml
+++ b/.github/workflows/create-build-branch.yml
@@ -31,10 +31,13 @@ jobs:
       - name: Install Compucorp-Civicrm-Aws-Sns-Sms dependencies
         run: composer install
 
+      - name: Remove gitignore file
+        run: rm -rf .gitignore
+
       - name: Commit and push changes
         uses: EndBug/add-and-commit@v7
         with:
           branch: ${{ github.event.pull_request.base.ref  }}-build
-          message: 'Add composer vendor'
-          add: './vendor -f'
+          message: 'Add vendor folder and remove gitignore'
+          add: '["./vendor -f", "./.gitignore"]'
           push: true


### PR DESCRIPTION
## Overview
This pr modifies the github action that creates the build branches to remove the gitignore file from the build branches.